### PR TITLE
Refactors logger command and build script

### DIFF
--- a/cmd/osml/cmd/logger.go
+++ b/cmd/osml/cmd/logger.go
@@ -42,43 +42,55 @@ var loggerWriteCmd = &cobra.Command{
 	Short: "write the osmlogger configuration",
 	Long:  `write the open sea map logger configuration`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		seatalk, _ := cmd.Flags().GetBool("seatalk")
-		baudA, _ := cmd.Flags().GetInt16("baudA")
-		baudB, _ := cmd.Flags().GetInt16("baudB")
-		vesselID, _ := cmd.Flags().GetInt16("vesselid")
-		gyro, _ := cmd.Flags().GetBool("gyro")
-		supply, _ := cmd.Flags().GetBool("supply")
-		cfg := logger.NewLoggerConfig().
-			WithBaudA(baudA).
-			WithBaudB(baudB).
-			WithGyro(gyro).
-			WithSupply(supply).
-			WithSeatalk(seatalk).
-			WithVesselID(vesselID)
-		err := cfg.Validate()
+		cfg, err := createCFG(cmd)
 		if err != nil {
 			return err
 		}
 		sdformat, _ := cmd.Flags().GetBool("sdformat")
 		if sdformat {
-			OutputWithJSONCheckf("formatting sd card at %s\n", sdCardFolder)
-			err = sdformatter.FormatFAT32(sdCardFolder)
-			if err != nil {
+			if err := formatSDCard(); err != nil {
 				return err
 			}
-			OutputWithJSONCheckf("sd card at %s formatted\n", sdCardFolder)
 		}
 		sdlabel, _ := cmd.Flags().GetString("sdlabel")
 		if sdlabel != "" {
-			OutputWithJSONCheckf("setting the label of sd card to %s on %s\n", sdlabel, sdCardFolder)
-			err = sdformatter.SetLabel(sdCardFolder, sdlabel)
+			if err := labelSDCard(sdlabel); err != nil {
+				return err
+			}
+		}
+		if err := cfg.WriteToSDCard(sdCardFolder); err != nil {
+			return err
+		}
+		if JSONOutput {
+			js, err := cfg.JSON()
 			if err != nil {
 				return err
 			}
-			OutputWithJSONCheckf("label set to %s on %s\n", sdlabel, sdCardFolder)
+			fmt.Println(js)
+			return nil
 		}
-		err = cfg.WriteToSDCard(sdCardFolder)
-		if err != nil {
+		OutputWithJSONCheckf("configuration written to %s/config.dat\n", sdCardFolder)
+		OutputWithJSONCheckf("config: %s\n", cfg.String())
+		return nil
+	},
+}
+
+var loggerInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "init a new sd card",
+	Long:  `initialise a new sd card for usage with the depth logger`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cfg := logger.NewLoggerConfig()
+		if err := formatSDCard(); err != nil {
+			return err
+		}
+		sdlabel, _ := cmd.Flags().GetString("sdlabel")
+		if sdlabel != "" {
+			if err := labelSDCard(sdlabel); err != nil {
+				return err
+			}
+		}
+		if err := cfg.WriteToSDCard(sdCardFolder); err != nil {
 			return err
 		}
 		if JSONOutput {
@@ -110,4 +122,48 @@ func init() {
 	loggerWriteCmd.Flags().BoolP("supply", "", false, "write internal supply data to the data files")
 	loggerWriteCmd.Flags().Bool("sdformat", false, "format the sd card before writing the configuration")
 	loggerWriteCmd.Flags().String("sdlabel", "", "setting the label of the sd card")
+
+	loggerCmd.AddCommand(loggerInitCmd)
+	loggerInitCmd.Flags().String("sdlabel", "", "setting the label of the sd card")
+}
+
+func createCFG(cmd *cobra.Command) (*logger.LoggerConfig, error) {
+	seatalk, _ := cmd.Flags().GetBool("seatalk")
+	baudA, _ := cmd.Flags().GetInt16("baudA")
+	baudB, _ := cmd.Flags().GetInt16("baudB")
+	vesselID, _ := cmd.Flags().GetInt16("vesselid")
+	gyro, _ := cmd.Flags().GetBool("gyro")
+	supply, _ := cmd.Flags().GetBool("supply")
+	cfg := logger.NewLoggerConfig().
+		WithBaudA(baudA).
+		WithBaudB(baudB).
+		WithGyro(gyro).
+		WithSupply(supply).
+		WithSeatalk(seatalk).
+		WithVesselID(vesselID)
+	err := cfg.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func formatSDCard() error {
+	OutputWithJSONCheckf("formatting sd card at %s\n", sdCardFolder)
+	err := sdformatter.FormatFAT32(sdCardFolder)
+	if err != nil {
+		return err
+	}
+	OutputWithJSONCheckf("sd card at %s formatted\n", sdCardFolder)
+	return nil
+}
+
+func labelSDCard(sdlabel string) error {
+	OutputWithJSONCheckf("setting the label of sd card to %s on %s\n", sdlabel, sdCardFolder)
+	err := sdformatter.SetLabel(sdCardFolder, sdlabel)
+	if err != nil {
+		return err
+	}
+	OutputWithJSONCheckf("label set to %s on %s\n", sdlabel, sdCardFolder)
+	return nil
 }

--- a/cmd/osml/cmd/logger.go
+++ b/cmd/osml/cmd/logger.go
@@ -46,18 +46,6 @@ var loggerWriteCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		sdformat, _ := cmd.Flags().GetBool("sdformat")
-		if sdformat {
-			if err := formatSDCard(); err != nil {
-				return err
-			}
-		}
-		sdlabel, _ := cmd.Flags().GetString("sdlabel")
-		if sdlabel != "" {
-			if err := labelSDCard(sdlabel); err != nil {
-				return err
-			}
-		}
 		if err := cfg.WriteToSDCard(sdCardFolder); err != nil {
 			return err
 		}
@@ -118,10 +106,8 @@ func init() {
 	loggerWriteCmd.Flags().Int16P("baudA", "a", 4800, "channel A communication baud rate")
 	loggerWriteCmd.Flags().Int16P("baudB", "b", 4800, "channel B communication baud rate")
 	loggerWriteCmd.Flags().Int16P("vesselid", "", 0, "id of the vessel to set or get the configuration")
-	loggerWriteCmd.Flags().BoolP("gyro", "", true, "write internal gyro data to the data files")
+	loggerWriteCmd.Flags().BoolP("gyro", "", false, "write internal gyro data to the data files")
 	loggerWriteCmd.Flags().BoolP("supply", "", false, "write internal supply data to the data files")
-	loggerWriteCmd.Flags().Bool("sdformat", false, "format the sd card before writing the configuration")
-	loggerWriteCmd.Flags().String("sdlabel", "", "setting the label of the sd card")
 
 	loggerCmd.AddCommand(loggerInitCmd)
 	loggerInitCmd.Flags().String("sdlabel", "", "setting the label of the sd card")

--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -5,4 +5,5 @@ cd dist\osml_windows_amd64_v1
 osml.exe version
 rem go build -ldflags="-s -w" -o osml.exe cmd/osml/main.go
 copy osml.exe c:\tools\
+copy osml.exe ..\..
 cd ..\..


### PR DESCRIPTION
Updates the logger command and build process.

- Removes SD card formatting and labeling options from the `loggerWriteCmd`.
- Changes the default value of the `gyro` flag to `false`.
- Updates the build script to copy the executable to a new location.

Relates to #19